### PR TITLE
Support building and installing under GNU/Linux

### DIFF
--- a/Eulexis.pro
+++ b/Eulexis.pro
@@ -31,13 +31,22 @@ RESOURCES += src/Eulexis.qrc
 
 !macx:
 {
-    RC_ICONS = src/res/Eulexis.ico
     data.path = bin/ressources
     data.files =  Eulexis_data/*
-    deploy.depends += install
     INSTALLS += data
-    deploy.commands = windeployqt bin/Eulexis.exe
-    QMAKE_EXTRA_TARGETS += deploy
+    win32|win64:
+    {
+        RC_ICONS = src/res/Eulexis.ico
+        deploy.depends += install
+        deploy.commands = windeployqt bin/Eulexis.exe
+        QMAKE_EXTRA_TARGETS += deploy
+    }
+    linux:
+    {
+        target.path = bin
+        target.file = $$TARGET
+        INSTALLS += target
+    }
 }
 macx:
 {

--- a/Greek_converter.pro
+++ b/Greek_converter.pro
@@ -34,8 +34,17 @@ RESOURCES += src/Greek_converter.qrc
     data.files =  Eulexis_data/betunicode_gr.csv
     deploy.depends += install
     INSTALLS += data
-    deploy.commands = windeployqt bin/Greek_converter.exe
-    QMAKE_EXTRA_TARGETS += deploy
+    win32|win64:
+    {
+        deploy.commands = windeployqt bin/Greek_converter.exe
+        QMAKE_EXTRA_TARGETS += deploy
+    }
+    linux:
+    {
+        target.path = bin
+        target.file = $$TARGET
+        INSTALLS += target
+    }
 }
 macx:
 {

--- a/Greek_converter.pro
+++ b/Greek_converter.pro
@@ -32,10 +32,10 @@ RESOURCES += src/Greek_converter.qrc
     RC_ICONS = src/res/Eulexis.ico
     data.path = bin/ressources
     data.files =  Eulexis_data/betunicode_gr.csv
-    deploy.depends += install
     INSTALLS += data
     win32|win64:
     {
+        deploy.depends += install
         deploy.commands = windeployqt bin/Greek_converter.exe
         QMAKE_EXTRA_TARGETS += deploy
     }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ It is also compatible with GNU/Linux, so you can compile this software from the 
 
 Installation packages for Mac OS and Windows are downloadable on this page: https://outils.biblissima.fr/en/eulexis/
 
+Under GNU/Linux, provided that you have the Qt libraries installed on your system, build this project from within QtCreator, then run `make install` in the build directory. This will result in the creation of a `bin/` directory in local copy of this repository, containing the `Eulexis` binary and the related ressources folder. You can move and rename this `bin/` directory at your convenience.
+
 ### Update 2020-01-18
 
 ## Vocab-list and OCR correction


### PR DESCRIPTION
As there is no standard way to deploy an application across Linux systems, I simply gave a way to build the binaries and to obtain a `bin` directory under which the binary and the resources are located. One could consider distributing the resulting folder as an archive on the website, but in the future it would be preferable to implement one of the solutions listed [here](https://wiki.qt.io/Deploying_a_Qt5_Application_Linux).